### PR TITLE
Implement gspread ingestion

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,24 @@
 # codex
+
+This project ingests content pack definitions from a Google Sheet.
+
+## Setup
+
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Provide a Google service account credentials JSON file and update
+   `config.GOOGLE_SHEETS_CREDENTIALS_JSON` with its path. Also set
+   `config.GOOGLE_SHEETS_DOCUMENT_KEY` to the ID of your Google Sheet.
+
+The script uses `gspread` to access the sheet; the older `googleapiclient`
+packages are no longer required.
+
+## Usage
+
+Run the ingestion script:
+
+```bash
+python ingest.py
+```

--- a/config.py
+++ b/config.py
@@ -1,0 +1,7 @@
+# Configuration settings
+
+# Path to Google service account credentials JSON file
+GOOGLE_SHEETS_CREDENTIALS_JSON = 'credentials.json'
+
+# Google Sheets document key
+GOOGLE_SHEETS_DOCUMENT_KEY = 'your_google_sheet_key'

--- a/ingest.py
+++ b/ingest.py
@@ -1,0 +1,27 @@
+"""Utility to ingest content packs from a Google Sheet."""
+
+import gspread
+from google.oauth2.service_account import Credentials
+
+import config
+
+SCOPES = ["https://www.googleapis.com/auth/spreadsheets.readonly"]
+
+def get_content_packs():
+    """Retrieve content packs listed in the Google Sheet."""
+    creds = Credentials.from_service_account_file(
+        config.GOOGLE_SHEETS_CREDENTIALS_JSON, scopes=SCOPES
+    )
+    gc = gspread.authorize(creds)
+    worksheet = gc.open_by_key(config.GOOGLE_SHEETS_DOCUMENT_KEY).worksheet("ContentPacks")
+    rows = worksheet.get_all_records()
+    packs = []
+    for row in rows:
+        if row:
+            packs.append(row)
+    return packs
+
+if __name__ == "__main__":
+    from pprint import pprint
+
+    pprint(get_content_packs())

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+# Project dependencies
+requests
+pandas
+gspread


### PR DESCRIPTION
## Summary
- add ingestion script using gspread
- document new setup requirements
- add project requirements

## Testing
- `pip install -r requirements.txt`
- `python ingest.py` *(fails: FileNotFoundError for credentials)*

------
https://chatgpt.com/codex/tasks/task_e_685dcb74a588832093d0fc3e431ecdbf