### PR TITLE
Add FastAPI skeleton for article writing assistant

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,13 @@ Fill in `config.py` with your credentials. By default the job runs at the top of
 ## Free scheduling via GitHub Actions
 
 You can run the automation without hosting costs by using [GitHub Actions](https://docs.github.com/en/actions). A workflow file is included in `.github/workflows/scheduler.yml` that runs `main.py` at the start of every hour. Set the required secrets (e.g. `INSTAGRAM_ACCESS_TOKEN`) in your repository settings and enable the workflow.
+
+## Article Writing Assistant
+
+A FastAPI backend (`backend/`) provides endpoints powered by GPT-4 to help orthopedics researchers write SCIE-ready manuscripts. Example usage:
+
+```bash
+uvicorn backend.main:app --reload
+```
+
+POST `/hypothesis` with JSON `{ "topic": "anterior cruciate ligament" }` to generate SMART hypotheses.

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,10 @@
+from fastapi import FastAPI
+from .routers import hypothesis
+
+app = FastAPI(title="Article Assistant")
+
+app.include_router(hypothesis.router)
+
+@app.get('/')
+async def root():
+    return {"message": "Article Assistant API"}

--- a/backend/prompt_manager.py
+++ b/backend/prompt_manager.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+
+class PromptManager:
+    """Load prompt templates from the prompts directory."""
+
+    def __init__(self, base_dir: str = "prompts"):
+        self.base_dir = Path(__file__).resolve().parent / base_dir
+
+    def load(self, name: str) -> str:
+        path = self.base_dir / name
+        if not path.exists():
+            raise FileNotFoundError(f"Prompt {name} not found")
+        return path.read_text(encoding="utf-8")

--- a/backend/prompts/hypothesis_prompt.txt
+++ b/backend/prompts/hypothesis_prompt.txt
@@ -1,0 +1,3 @@
+You are an academic assistant specialized in orthopedics. Generate three SMART hypotheses about the following topic:
+
+{topic}

--- a/backend/prompts/literature_summary_prompt.txt
+++ b/backend/prompts/literature_summary_prompt.txt
@@ -1,0 +1,3 @@
+Summarize the following article in 2-3 sentences:
+
+{abstract}

--- a/backend/routers/hypothesis.py
+++ b/backend/routers/hypothesis.py
@@ -1,0 +1,22 @@
+from fastapi import APIRouter
+from pydantic import BaseModel
+from openai import ChatCompletion
+
+from ..prompt_manager import PromptManager
+
+router = APIRouter()
+manager = PromptManager()
+
+class HypothesisRequest(BaseModel):
+    topic: str
+
+@router.post('/hypothesis')
+async def generate_hypothesis(req: HypothesisRequest):
+    prompt_template = manager.load('hypothesis_prompt.txt')
+    prompt = prompt_template.format(topic=req.topic)
+    response = ChatCompletion.create(
+        model="gpt-4",
+        messages=[{"role": "user", "content": prompt}]
+    )
+    text = response.choices[0].message['content']
+    return {"hypotheses": text.strip()}

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,7 @@ google-api-python-client
 google-auth-httplib2
 google-auth-oauthlib
 python-dotenv
+fastapi
+uvicorn
+openai
+pandas


### PR DESCRIPTION
## Summary
- build `backend` directory with FastAPI application
- add `PromptManager` and first prompt templates
- add `/hypothesis` endpoint using GPT-4
- document basic usage in README
- include new Python dependencies

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f1ee4768c8320b959284b7fe13f06