### PR TITLE
Add local summarizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,16 @@ Fill in `config.py` with your credentials. By default the job runs at the top of
 ## Free scheduling via GitHub Actions
 
 You can run the automation without hosting costs by using [GitHub Actions](https://docs.github.com/en/actions). A workflow file is included in `.github/workflows/scheduler.yml` that runs `main.py` at the start of every hour. Set the required secrets (e.g. `INSTAGRAM_ACCESS_TOKEN`) in your repository settings and enable the workflow.
+
+## Article Writing Assistant
+
+A FastAPI backend (`backend/`) provides endpoints powered by a local HuggingFace model (e.g. DeepSeek R1) to help orthopedics researchers write SCIE-ready manuscripts. Example usage:
+
+```bash
+uvicorn backend.main:app --reload
+```
+
+POST `/hypothesis` with JSON `{ "topic": "anterior cruciate ligament" }` to generate SMART hypotheses.
+POST `/summary` with JSON `{ "text": "..." }` to get a short literature summary using a local TextRank algorithm.
+
+Set the environment variable `HF_MODEL_PATH` to the directory of a compatible transformer model (for example, a locally downloaded DeepSeek R1 checkpoint). The summarization endpoint relies on the `summa` package and works fully offline.

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,11 @@
+from fastapi import FastAPI
+from .routers import hypothesis, summary
+
+app = FastAPI(title="Article Assistant")
+
+app.include_router(hypothesis.router)
+app.include_router(summary.router)
+
+@app.get('/')
+async def root():
+    return {"message": "Article Assistant API"}

--- a/backend/prompt_manager.py
+++ b/backend/prompt_manager.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+
+class PromptManager:
+    """Load prompt templates from the prompts directory."""
+
+    def __init__(self, base_dir: str = "prompts"):
+        self.base_dir = Path(__file__).resolve().parent / base_dir
+
+    def load(self, name: str) -> str:
+        path = self.base_dir / name
+        if not path.exists():
+            raise FileNotFoundError(f"Prompt {name} not found")
+        return path.read_text(encoding="utf-8")

--- a/backend/prompts/hypothesis_prompt.txt
+++ b/backend/prompts/hypothesis_prompt.txt
@@ -1,0 +1,3 @@
+You are an academic assistant specialized in orthopedics. Generate three SMART hypotheses about the following topic:
+
+{topic}

--- a/backend/prompts/literature_summary_prompt.txt
+++ b/backend/prompts/literature_summary_prompt.txt
@@ -1,0 +1,3 @@
+Summarize the following article in 2-3 sentences:
+
+{abstract}

--- a/backend/routers/__init__.py
+++ b/backend/routers/__init__.py
@@ -1,0 +1,3 @@
+from . import hypothesis, summary
+
+__all__ = ["hypothesis", "summary"]

--- a/backend/routers/hypothesis.py
+++ b/backend/routers/hypothesis.py
@@ -1,0 +1,18 @@
+from fastapi import APIRouter
+from pydantic import BaseModel
+from ..prompt_manager import PromptManager
+from ..services.ai import get_provider
+
+router = APIRouter()
+manager = PromptManager()
+provider = get_provider()
+
+class HypothesisRequest(BaseModel):
+    topic: str
+
+@router.post('/hypothesis')
+async def generate_hypothesis(req: HypothesisRequest):
+    prompt_template = manager.load('hypothesis_prompt.txt')
+    prompt = prompt_template.format(topic=req.topic)
+    text = await provider.generate(prompt)
+    return {"hypotheses": text.strip()}

--- a/backend/routers/summary.py
+++ b/backend/routers/summary.py
@@ -1,0 +1,13 @@
+from fastapi import APIRouter
+from pydantic import BaseModel
+from ..services.summarizer import summarize_text
+
+router = APIRouter()
+
+class SummaryRequest(BaseModel):
+    text: str
+
+@router.post('/summary')
+async def summarize(req: SummaryRequest):
+    summary = await summarize_text(req.text)
+    return {"summary": summary.strip()}

--- a/backend/services/ai.py
+++ b/backend/services/ai.py
@@ -1,0 +1,33 @@
+from typing import Optional
+import os
+
+try:
+    from transformers import pipeline
+except ImportError:  # transformers not installed
+    pipeline = None
+
+class AIProvider:
+    """Base class for text generation providers."""
+
+    async def generate(self, prompt: str) -> str:
+        raise NotImplementedError
+
+
+class HuggingFaceProvider(AIProvider):
+    """Generate text using a local HuggingFace model."""
+
+    def __init__(self, model_path: Optional[str] = None):
+        if pipeline is None:
+            raise RuntimeError("transformers must be installed to use HuggingFaceProvider")
+        self.model_path = model_path or os.environ.get("HF_MODEL_PATH", "gpt2")
+        self.generator = pipeline("text-generation", model=self.model_path)
+
+    async def generate(self, prompt: str) -> str:
+        outputs = self.generator(prompt, max_length=512, num_return_sequences=1)
+        return outputs[0]["generated_text"]
+
+
+def get_provider() -> AIProvider:
+    """Return the configured AI provider. Defaults to HuggingFaceProvider."""
+
+    return HuggingFaceProvider()

--- a/backend/services/summarizer.py
+++ b/backend/services/summarizer.py
@@ -1,0 +1,6 @@
+from summa.summarizer import summarize
+
+async def summarize_text(text: str, ratio: float = 0.2) -> str:
+    """Return a short summary using TextRank."""
+    # summa expects raw text; ratio controls summary length
+    return summarize(text, ratio=ratio)

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,8 @@ google-api-python-client
 google-auth-httplib2
 google-auth-oauthlib
 python-dotenv
+fastapi
+uvicorn
+transformers
+pandas
+summa


### PR DESCRIPTION
## Summary
- expose `/summary` endpoint using the `summa` TextRank algorithm
- include the new router in `main.py`
- document the summarization route and offline support
- depend on the `summa` package for local NLP

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f1ee4768c8320b959284b7fe13f06